### PR TITLE
Fix quotes around null byte

### DIFF
--- a/garden_rails.gemspec
+++ b/garden_rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
       'public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split('\x0').reject do |f|
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = 'exe'

--- a/lib/garden_rails.rb
+++ b/lib/garden_rails.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'garden_rails/version'
-require 'garden_rails/railtie' if defined?(Rails)
+require 'railtie' if defined?(Rails)
 
 module GardenRails
 end

--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RakeGem::Railtie < Rails::Railtie
+class GardenRails::Railtie < Rails::Railtie
   rake_tasks do
     load 'tasks/generate_yard.rake'
   end


### PR DESCRIPTION
was getting `path name contains null byte` when installing it